### PR TITLE
設定ファイルの上書きが正常に行われない不具合を修正

### DIFF
--- a/src/main/java/firis/lmlib/client/resources/LMTextureResourcePack.java
+++ b/src/main/java/firis/lmlib/client/resources/LMTextureResourcePack.java
@@ -190,7 +190,7 @@ public class LMTextureResourcePack implements IResourcePack {
 				//リソースパック用設定ファイル出力
 				Path packmetaPath = Paths.get(basePath.toString(), "pack.mcmeta");
 				String packmeta = "{\"pack\": {\"pack_format\": 3,\"description\": \"LittleMaidReengaged Developer Resourcepack\"}}";
-				Files.write(packmetaPath, Arrays.asList(packmeta), Charset.forName("UTF-8"), StandardOpenOption.CREATE);
+				Files.write(packmetaPath, Arrays.asList(packmeta), Charset.forName("UTF-8"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 				
 			} catch (Exception e) {
 				e.printStackTrace();

--- a/src/main/java/firis/lmlib/common/helper/ResourceFileHelper.java
+++ b/src/main/java/firis/lmlib/common/helper/ResourceFileHelper.java
@@ -59,7 +59,7 @@ public class ResourceFileHelper {
 			}
 			
 			//ファイルの上書き
-			Files.write(filePath, jsonList, Charset.forName("UTF-8"), StandardOpenOption.CREATE);
+			Files.write(filePath, jsonList, Charset.forName("UTF-8"), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 			ret = true;
 			
 		} catch (IOException e) {


### PR DESCRIPTION
StandardOpenOption.TRUNCATE_EXISTINGが指定されていないので
出力後のファイルが以前のものよりも小さい場合、残骸が残って
次回以降の読み込みに失敗するのを直します。